### PR TITLE
feat: added snyk scan to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  snyk: snyk/snyk@1.7.0
+
 executors:
   default-executor:
     machine:
@@ -13,6 +16,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test
+      - snyk/scan
 
   deploy:
     executor: default-executor
@@ -23,7 +27,9 @@ jobs:
 workflows:
   build_test_deploy:
     jobs:
-      - build_and_test
+      - build_and_test:
+          context:
+            - snyk-security
       - deploy:
           requires:
             - build_and_test


### PR DESCRIPTION
- Adds the latest Snyk orb to the CircleCI configuration so that it is available for the pipeline
- Adds the snyk/scan command after installation and testing of the project
- Adds a context called "snyk-security" to the workflow job that is running the snyk/scan command
- The PR should only add the snyk/scan step into a single job
- The PR should preserve all existing circleci contexts
- If the snyk orb is already present, update it to version snyk/snyk@1.7.0